### PR TITLE
Pin aws provider to version

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "us-west-2"
+  version = "~> 2.2"
+  region  = "us-west-2"
 }
 
 resource "random_string" "r_string" {


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
N/A
##### Summary of change(s):
I found that the test for this module does not have a pinned aws provider version. I've gone ahead and pinned it to a version.
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
N/A
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
N/A
##### If input variables or output variables have changed or has been added, have you updated the README?
N/A
##### Do examples need to be updated based on changes?
N/A
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.